### PR TITLE
allowing the "focus-visible" CSS class

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = {
     "selector-attribute-operator-space-before": "never",
     "selector-combinator-space-after": "always",
     "selector-combinator-space-before": "always",
-    "selector-class-pattern": "^d2l-",
+    "selector-class-pattern": "(^d2l-)|(^focus-visible$)",
     "selector-descendant-combinator-no-non-space": true,
     "selector-list-comma-space-before": "never",
     "selector-max-empty-lines": 0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightspace-ui/stylelint-config",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Common Brightspace stylelint configs.",
   "repository": "https://github.com/BrightspaceUI/stylelint-config.git",
   "publishConfig": {


### PR DESCRIPTION
Ran into this while integrating the `:focus-visible` polyfill into core. It uses the `.focus-visible` CSS class to function, so I think we want to support this class name globally.