### PR TITLE
Change to not sort properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = {
       "custom-properties",
       "declarations"
     ],
-    "order/properties-alphabetical-order": true,
+    "order/properties-alphabetical-order": false,
     "property-case": "lower",
     "selector-attribute-brackets-space-inside": "never",
     "selector-attribute-operator-space-after": "never",

--- a/index.js
+++ b/index.js
@@ -69,7 +69,6 @@ module.exports = {
       "custom-properties",
       "declarations"
     ],
-    "order/properties-alphabetical-order": false,
     "property-case": "lower",
     "selector-attribute-brackets-space-inside": "never",
     "selector-attribute-operator-space-after": "never",


### PR DESCRIPTION
@dbatiste @dlockhart what value do we find from forcing a sorted order of CSS properties? We tend to group them logically instead of just sorting them to help with quicker parsing and readability from a development stand point. I'd like to either remove this rule fully or set it to false and leave ordering up to the developer of the code.