### PR TITLE
Proposal: do not require CSS properties to be alphabetically sorted

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = {
       "custom-properties",
       "declarations"
     ],
-    "order/properties-alphabetical-order": true,
+    "order/properties-alphabetical-order": false,
     "property-case": "lower",
     "selector-attribute-brackets-space-inside": "never",
     "selector-attribute-operator-space-after": "never",


### PR DESCRIPTION
I suggest we remove this rule as it is a fairly arbitrary rule that can make css harder to read and work with.

The most egregious problem with the rule is that it prevents some related properties from being put together. For example, `top`, `buttom`, `left`, and `right` will all go in different places so its not easy to see position modifying properties at a glace.

Similarly, it prevents `margin`, `padding`, and `border` properties from being together.

Also `width` and `height`. And `max-width`, etc.

It makes more sense for a human to decide what's more readable than enforcing alphabetic ordering which only really helps with locating properties you already know the name of in a very large css class.