### PR TITLE
Update to support stylelint v14.

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,10 @@ module.exports = {
     {
       "files": ["**/*.js"],
       "customSyntax": "@stylelint/postcss-css-in-js"
+    },
+    {
+      "files": ["**/*.html"],
+      "customSyntax": "postcss-html"
     }
-	]
+  ]
 };

--- a/index.js
+++ b/index.js
@@ -76,7 +76,6 @@ module.exports = {
     "selector-attribute-operator-space-before": "never",
     "selector-combinator-space-after": "always",
     "selector-combinator-space-before": "always",
-    "selector-class-pattern": "(^d2l-)|(^focus-visible$)",
     "selector-descendant-combinator-no-non-space": true,
     "selector-list-comma-space-before": "never",
     "selector-max-empty-lines": 0,

--- a/index.js
+++ b/index.js
@@ -93,5 +93,11 @@ module.exports = {
     "value-list-comma-space-after": "always-single-line",
     "value-list-comma-space-before": "never",
     "value-list-max-empty-lines": 0
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/*.js"],
+      "customSyntax": "@stylelint/postcss-css-in-js"
+    }
+	]
 };

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "stylelint": "^13",
-    "stylelint-config-recommended": "^5",
-    "stylelint-order": "^4"
+    "@stylelint/postcss-css-in-js": "^0.37.2",
+    "postcss-syntax": "^0.36.2",
+    "stylelint": "^14",
+    "stylelint-config-recommended": "^6",
+    "stylelint-order": "^5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@stylelint/postcss-css-in-js": "^0.37.2",
+    "postcss-html": "^1.2.0",
     "postcss-syntax": "^0.36.2",
     "stylelint": "^14",
     "stylelint-config-recommended": "^6",


### PR DESCRIPTION
This PR updates deps and config with necessary changes to support v14 of stylelint ([Migration Guide](https://github.com/stylelint/stylelint/blob/main/docs/migration-guide/to-14.md#migrating-to-1400)).

It configures syntax handlers for CSS in JS, and also CSS in HTML.  If requested, we can configure to handle other file extensions, and other syntax handlers.

I also removed the `selector-class-pattern` because we no longer support any browsers that do not support native shadowDOM.
