### PR TITLE
Update to latest stylelint and stylelint-config-recommended.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "@stylelint/postcss-css-in-js": "^0.38",
     "postcss-html": "^1",
     "postcss-syntax": "^0.36",
-    "stylelint": "^14",
-    "stylelint-config-recommended": "^9",
+    "stylelint": "^15",
+    "stylelint-config-recommended": "^12",
     "stylelint-order": "^6"
   }
 }


### PR DESCRIPTION
I'm not entirely sure why these didn't get picked up by dependabot.

Ran these version against core and everything looks "ok".  `stylelint@15` comes with deprecation warnings for the rules that they plan to remove in the next major release. Will deal with those as a separate change.