### PR TITLE
Pin stylelint version until issue is fixed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@stylelint/postcss-css-in-js": "^0.38",
     "postcss-html": "^1",
     "postcss-syntax": "^0.36",
-    "stylelint": "^15",
+    "stylelint": "15.9.0",
     "stylelint-config-recommended": "^13",
     "stylelint-order": "^6",
     "stylelint-stylistic": "^0.4"


### PR DESCRIPTION
Pin stylelint to v15.9.0 until the community supported stylistic rules plugin can be updated to not use the utils that were removed from stylelint.

Ref: https://github.com/elirasza/stylelint-stylistic/issues/12