### PR TITLE
Pin stylelint-config-recommended.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "postcss-html": "^1",
     "postcss-syntax": "^0.36",
     "stylelint": "15.9.0",
-    "stylelint-config-recommended": "^13",
+    "stylelint-config-recommended": "12",
     "stylelint-order": "^6",
     "stylelint-stylistic": "^0.4"
   }


### PR DESCRIPTION
Pin stylelint-config-recommended since v13 has a peer dependency on stylelint 15.10.0 (which we've pinned).