### PR TITLE
Unpin stylelint since the stylistic rules plugin has been fixed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@stylelint/postcss-css-in-js": "^0.38",
     "postcss-html": "^1",
     "postcss-syntax": "^0.36",
-    "stylelint": "15.9.0",
+    "stylelint": "^15",
     "stylelint-config-recommended": "12",
     "stylelint-order": "^6",
     "stylelint-stylistic": "^0.4"


### PR DESCRIPTION
The `stylelint-stylistic` plugin has been fixed as per: https://github.com/elirasza/stylelint-stylistic/pull/13 so we can unpin stylelint.