### PR TITLE
Disable the media-query-no-invalid rule since it conflicts with JavaScript.

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ module.exports = {
 		"stylistic/media-query-list-comma-newline-after": "always-multi-line",
 		"stylistic/media-query-list-comma-space-after": "always-single-line",
 		"stylistic/media-query-list-comma-space-before": "never",
+		"media-query-no-invalid": null,
 		"no-descending-specificity": null,
 		"stylistic/no-eol-whitespace": [true, {
 			"ignore": ["empty-lines"]


### PR DESCRIPTION
This PR disables the [media-query-no-invalid](https://github.com/stylelint/stylelint/blob/main/lib/rules/media-query-no-invalid/README.md) that was added in [stylelint-config-recommended@13](https://github.com/stylelint/stylelint-config-recommended). 

The rule causes the following (reasonable example from copycat) scenario to fail:
```css
@media (max-width: ${MEDIA_BREAKPOINT}px) {
	.d2l-heading-1 {
		margin: 1.2rem 0;
	}
}
```